### PR TITLE
Add .nuspec file to project

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
     - "v[0-9]+.[0-9]+.[0-9]+"
+    paths:
+      - 'HttpClientToCurlGenerator.nuspec'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,11 +26,30 @@ jobs:
     - name: Test
       run: dotnet test --configuration Release /p:Version=${VERSION} --no-build
       working-directory: src/HttpClientToCurl
-    - name: Pack
-      run: dotnet pack --configuration Release /p:Version=${VERSION} --no-build --output .
-      working-directory: src/HttpClientToCurl
-    - name: Push
-      run: dotnet nuget push HttpClientToCurl.${VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${GITHUB_TOKEN}
-      working-directory: src/HttpClientToCurl
-      env:
-        GITHUB_TOKEN: ${{ secrets.NUGET_API_KEY }}
+    # - name: Pack
+    #   run: dotnet pack --configuration Release /p:Version=${VERSION} --no-build --output .
+    #   working-directory: src/HttpClientToCurl
+    # - name: Push
+    #   run: dotnet nuget push HttpClientToCurl.${VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${GITHUB_TOKEN}
+    #   working-directory: src/HttpClientToCurl
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.NUGET_API_KEY }}
+  publish:
+    name: Publish to NuGet.org
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout code
+
+      - uses: nuget/setup-nuget@v1
+        name: Setup NuGet
+        with:
+          nuget-version: '6.x'
+
+      - name: Create the package
+        run: nuget pack HttpClientToCurl.nuspec -NoDefaultExcludes
+        
+      - name: Publish the package
+        run: nuget push *.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}} -SkipDuplicate

--- a/HttpClientToCurlGenerator.nuspec
+++ b/HttpClientToCurlGenerator.nuspec
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+
+    <id>HttpClientToCurlGenerator</id>
+    <version>2.0.3</version>
+    <title>Generating Curl script of HttpClient</title>
+    <authors>amingolmahalle</authors>
+    <description>An extension for generating Curl script of HttpClient</description>
+    <summary>
+      This extension will help you to see whatever is set in **HttpClient** in the form of a curl script.
+    </summary>
+    <releaseNotes>
+      Some improvements.
+    </releaseNotes>
+    <readme>readme.md</readme>
+
+    <projectUrl>https://github.com/amingolmahalle/HttpClientToCurlGenerator</projectUrl>
+    <repository type="git" url="https://github.com/amingolmahalle/HttpClientToCurlGenerator.git" branch="master" />
+
+    <license type="file">LICENSE.md</license>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <tags>package json extension csharp dotnet curl aspnetcore nuget xml dotnetcore httpclient postman dotnet-core aspnet-core asp-net-core asp-net dotnet-standard nuget-package asp-net-core-web-api httpclients</tags>
+    <icon>icon.png</icon>
+    <readme>README.md</readme> 
+
+  </metadata>
+
+  <files> 
+    <file src="README.md" />
+    <file src=".\**" target="content" exclude="**\bin\**;**\obj\**;.\.vs\**;.\.vscode\**;.\.git\**;.\.github\workflows\dotnet.yml;.\.github\workflows\release.yml;.\.github\ISSUE_TEMPLATE\**;.\.github\icon.png;.\CODE_OF_CONDUCT.md;.\LICENSE;.\README.md;" />
+  </files>
+
+</package>


### PR DESCRIPTION
Based #25 issue we can add `.nuspec` file to manage Nuget pack and publish. But to use this feature we need to change `release.yml` file and test flow.