### PR TITLE
Update pre-commit hook to ignore build when cs files didn't change.

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,7 +1,23 @@
 #!/bin/sh
 
-echo "dotnet build"
+exists=0
+echo "do a check for .cs files in change set"
+while read status file; do
+    if [ "${file: -3}" == ".cs" ] ; then
+        exists=1
+        echo "find .cs file"
+        break
+    fi
+done <<<$(git diff --cached --name-status)
 
+echo $exists
+if [[ $exists -eq 0 ]] ; then
+    exit 0
+else
+    echo "exists .cs file, so build the project"
+fi
+
+echo "dotnet build"
 dotnet clean; dotnet build
 rc=$?
 


### PR DESCRIPTION
When I create any local commit, the pre-commit hook executes to build the project. But in some commits, I didn't change any C# files so it doesn't require rebuilding the project.
In this change, I ignored the pre-commit build when C# files didn't change.